### PR TITLE
fix: detect Cline and Roo config paths on Linux

### DIFF
--- a/scripts-mcp/lib/tools/cline.js
+++ b/scripts-mcp/lib/tools/cline.js
@@ -3,19 +3,51 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
-const { readConfig, writeConfig } = require('../config-io');
+const { writeConfig } = require('../config-io');
 
-const CONFIG_PATH = path.join(
-  os.homedir(),
-  'Library',
-  'Application Support',
-  'Code',
-  'User',
-  'globalStorage',
-  'saoudrizwan.claude-dev',
-  'settings',
-  'cline_mcp_settings.json'
-);
+function getCandidateConfigPaths() {
+  const home = os.homedir();
+  const appData = process.env.APPDATA;
+
+  const candidates = [
+    path.join(
+      home,
+      'Library',
+      'Application Support',
+      'Code',
+      'User',
+      'globalStorage',
+      'saoudrizwan.claude-dev',
+      'settings',
+      'cline_mcp_settings.json'
+    ),
+    path.join(
+      process.env.XDG_CONFIG_HOME || path.join(home, '.config'),
+      'Code',
+      'User',
+      'globalStorage',
+      'saoudrizwan.claude-dev',
+      'settings',
+      'cline_mcp_settings.json'
+    )
+  ];
+
+  if (appData) {
+    candidates.push(
+      path.join(
+        appData,
+        'Code',
+        'User',
+        'globalStorage',
+        'saoudrizwan.claude-dev',
+        'settings',
+        'cline_mcp_settings.json'
+      )
+    );
+  }
+
+  return candidates;
+}
 
 /**
  * Discovers the Cline MCP config file.
@@ -23,12 +55,17 @@ const CONFIG_PATH = path.join(
  * @returns {string | null} Absolute config path if the file exists, otherwise null.
  */
 function discover() {
-  try {
-    fs.accessSync(CONFIG_PATH, fs.constants.R_OK);
-    return CONFIG_PATH;
-  } catch (_) {
-    return null;
+  const candidates = getCandidateConfigPaths();
+  for (const configPath of candidates) {
+    try {
+      fs.accessSync(configPath, fs.constants.R_OK);
+      return configPath;
+    } catch (_) {
+      // Try next candidate.
+    }
   }
+
+  return null;
 }
 
 /**
@@ -119,6 +156,7 @@ function writeMcpServers(servers, configPath) {
 module.exports = {
   name: 'cline',
   discover,
+  getCandidateConfigPaths,
   parseMcpServers,
   writeMcpServers,
 };

--- a/scripts-mcp/lib/tools/cline.test.js
+++ b/scripts-mcp/lib/tools/cline.test.js
@@ -12,6 +12,12 @@ function tmpFile(name) {
   return path.join(TMPDIR, name);
 }
 
+function tmpDir(name) {
+  const dir = path.join(TMPDIR, name);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
 function writeRaw(filePath, content) {
   fs.writeFileSync(filePath, content, 'utf8');
 }
@@ -21,88 +27,133 @@ function readRaw(filePath) {
 }
 
 function cleanup() {
-  for (const file of fs.readdirSync(TMPDIR)) {
-    try { fs.unlinkSync(path.join(TMPDIR, file)); } catch (_) { /* best effort */ }
+  fs.rmSync(TMPDIR, { recursive: true, force: true });
+}
+
+const realHomedir = os.homedir;
+const realXdgConfigHome = process.env.XDG_CONFIG_HOME;
+const realAppData = process.env.APPDATA;
+let fakeHome = null;
+
+function stubHomedir(home) {
+  fakeHome = home;
+  os.homedir = () => fakeHome;
+}
+
+function restoreEnv() {
+  os.homedir = realHomedir;
+  if (realXdgConfigHome === undefined) {
+    delete process.env.XDG_CONFIG_HOME;
+  } else {
+    process.env.XDG_CONFIG_HOME = realXdgConfigHome;
+  }
+
+  if (realAppData === undefined) {
+    delete process.env.APPDATA;
+  } else {
+    process.env.APPDATA = realAppData;
   }
 }
 
-// Minimal stub of readConfig that reads from real filesystem
-// The actual module is imported inside each test so we can control the file state.
-// We test against the real configPath by setting up files at the expected location
-// via a tmpdir that we construct to mimic the real path structure.
-
 describe('cline', () => {
-  let cline;
-
   beforeEach(() => {
-    // Fresh require each time to avoid cached state
-    delete require.cache[require.resolve('./cline.js')];
-    cline = require('./cline.js');
+    restoreEnv();
   });
 
-  afterEach(() => cleanup());
+  afterEach(() => {
+    restoreEnv();
+    cleanup();
+  });
 });
 
-// --- discover() tests ---
-
 describe('cline discover()', () => {
-  const configPath = path.join(
-    os.homedir(),
-    'Library',
-    'Application Support',
-    'Code',
-    'User',
-    'globalStorage',
-    'saoudrizwan.claude-dev',
-    'settings',
-    'cline_mcp_settings.json'
-  );
+  it('returns macOS configPath when file exists', () => {
+    const home = tmpDir('home-macos');
+    const configPath = path.join(
+      home,
+      'Library',
+      'Application Support',
+      'Code',
+      'User',
+      'globalStorage',
+      'saoudrizwan.claude-dev',
+      'settings',
+      'cline_mcp_settings.json'
+    );
 
-  it('returns configPath when file exists', () => {
-    // Ensure the directory and file exist at the real Cline path
     fs.mkdirSync(path.dirname(configPath), { recursive: true });
     writeRaw(configPath, JSON.stringify({ mcpServers: {} }, null, 2));
 
+    stubHomedir(home);
     delete require.cache[require.resolve('./cline.js')];
     const cline = require('./cline.js');
-    const result = cline.discover();
 
-    assert.equal(result, configPath);
-
-    // Cleanup: remove the real file we created
-    try { fs.unlinkSync(configPath); } catch (_) { /* best effort */ }
-    // Attempt to clean up empty directories (best effort, ignore failures)
-    try { fs.rmdirSync(path.dirname(configPath)); } catch (_) { /* best effort */ }
-    try { fs.rmdirSync(path.dirname(path.dirname(configPath))); } catch (_) { /* best effort */ }
+    assert.equal(cline.discover(), configPath);
   });
 
-  it('returns null when file does not exist', () => {
-    // We need to test with a non-existent path. To avoid depending on
-    // whether the user's real Cline config exists, we temporarily rename
-    // it if present, then restore after.
-    let renamed = false;
-    if (fs.existsSync(configPath)) {
-      const bakPath = configPath + '.testbak';
-      fs.renameSync(configPath, bakPath);
-      renamed = true;
-    }
+  it('returns Linux configPath when file exists in XDG config home', () => {
+    const home = tmpDir('home-linux');
+    const xdgConfigHome = path.join(home, '.config');
+    const configPath = path.join(
+      xdgConfigHome,
+      'Code',
+      'User',
+      'globalStorage',
+      'saoudrizwan.claude-dev',
+      'settings',
+      'cline_mcp_settings.json'
+    );
 
-    try {
-      delete require.cache[require.resolve('./cline.js')];
-      const cline = require('./cline.js');
-      const result = cline.discover();
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    writeRaw(configPath, JSON.stringify({ mcpServers: {} }, null, 2));
 
-      assert.equal(result, null);
-    } finally {
-      if (renamed) {
-        const bakPath = configPath + '.testbak';
-        try { fs.renameSync(bakPath, configPath); } catch (_) { /* best effort */ }
-      }
-    }
+    stubHomedir(home);
+    process.env.XDG_CONFIG_HOME = xdgConfigHome;
+    delete require.cache[require.resolve('./cline.js')];
+    const cline = require('./cline.js');
+
+    assert.equal(cline.discover(), configPath);
+  });
+
+  it('returns Windows configPath when file exists in APPDATA', () => {
+    const home = tmpDir('home-windows');
+    const xdgConfigHome = path.join(home, '.config');
+    const appData = path.join(home, 'AppData', 'Roaming');
+    const configPath = path.join(
+      appData,
+      'Code',
+      'User',
+      'globalStorage',
+      'saoudrizwan.claude-dev',
+      'settings',
+      'cline_mcp_settings.json'
+    );
+
+    fs.rmSync(xdgConfigHome, { recursive: true, force: true });
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    writeRaw(configPath, JSON.stringify({ mcpServers: {} }, null, 2));
+
+    stubHomedir(home);
+    process.env.XDG_CONFIG_HOME = xdgConfigHome;
+    process.env.APPDATA = appData;
+    delete require.cache[require.resolve('./cline.js')];
+    const cline = require('./cline.js');
+
+    assert.equal(cline.discover(), configPath);
+  });
+
+  it('returns null when file does not exist in any supported location', () => {
+    const home = tmpDir('home-missing');
+
+    stubHomedir(home);
+    delete process.env.XDG_CONFIG_HOME;
+    delete process.env.APPDATA;
+    delete require.cache[require.resolve('./cline.js')];
+    const cline = require('./cline.js');
+
+    assert.equal(cline.discover(), null);
   });
 });
-
-// --- parseMcpServers() tests ---
 
 describe('cline parseMcpServers()', () => {
   it('extracts all fields including extras (timeout, type, disabled, alwaysAllow)', () => {
@@ -158,7 +209,6 @@ describe('cline parseMcpServers()', () => {
 
     assert.equal(result.length, 2);
 
-    // Minimal server: extra fields should be undefined or have defaults
     const minimal = result.find((s) => s.key === 'minimal');
     assert.equal(minimal.command, 'node');
     assert.deepStrictEqual(minimal.args, ['server.js']);
@@ -168,7 +218,6 @@ describe('cline parseMcpServers()', () => {
     assert.equal(minimal.alwaysAllow, undefined);
     assert.equal(minimal.env, undefined);
 
-    // Partial server: only specified extras present
     const partial = result.find((s) => s.key === 'partial');
     assert.equal(partial.command, 'npx');
     assert.equal(partial.timeout, 30);
@@ -227,8 +276,6 @@ describe('cline parseMcpServers()', () => {
   });
 });
 
-// --- writeMcpServers() tests ---
-
 describe('cline writeMcpServers()', () => {
   it('wraps in Cline schema preserving all extra fields', () => {
     const p = tmpFile('cline-write-full.json');
@@ -284,7 +331,6 @@ describe('cline writeMcpServers()', () => {
 
     assert.equal(server.command, 'node');
     assert.deepStrictEqual(server.args, ['server.js']);
-    // Extra fields should NOT be present as undefined
     assert.equal('timeout' in server, false, 'timeout should not be in output');
     assert.equal('type' in server, false, 'type should not be in output');
     assert.equal('disabled' in server, false, 'disabled should not be in output');
@@ -330,8 +376,6 @@ describe('cline writeMcpServers()', () => {
   });
 });
 
-// --- Round-trip test ---
-
 describe('cline round-trip', () => {
   it('parse -> pass through -> write preserves all extra fields', () => {
     const p = tmpFile('cline-roundtrip.json');
@@ -363,37 +407,16 @@ describe('cline round-trip', () => {
     delete require.cache[require.resolve('./cline.js')];
     const cline = require('./cline.js');
 
-    // Parse
     const parsed = cline.parseMcpServers(p, originalConfig);
-
-    // Write back
     const writeResult = cline.writeMcpServers(parsed, p);
     assert.equal(writeResult.ok, true);
 
-    // Read back and verify
     const roundTripped = JSON.parse(readRaw(p));
     const originalServers = originalConfig.mcpServers;
     const roundTrippedServers = roundTripped.mcpServers;
 
-    // Full server: all fields preserved
-    assert.deepStrictEqual(
-      roundTrippedServers['full-server'],
-      originalServers['full-server'],
-      'full-server should have identical round-trip'
-    );
-
-    // Partial server: all present fields preserved, absent fields stay absent
-    assert.deepStrictEqual(
-      roundTrippedServers['partial-server'],
-      originalServers['partial-server'],
-      'partial-server should have identical round-trip'
-    );
-
-    // Minimal server: only basic fields preserved
-    assert.deepStrictEqual(
-      roundTrippedServers['minimal-server'],
-      originalServers['minimal-server'],
-      'minimal-server should have identical round-trip'
-    );
+    assert.deepStrictEqual(roundTrippedServers['full-server'], originalServers['full-server']);
+    assert.deepStrictEqual(roundTrippedServers['partial-server'], originalServers['partial-server']);
+    assert.deepStrictEqual(roundTrippedServers['minimal-server'], originalServers['minimal-server']);
   });
 });

--- a/scripts-mcp/lib/tools/roo-code.js
+++ b/scripts-mcp/lib/tools/roo-code.js
@@ -4,17 +4,49 @@ const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
 
-const CONFIG_PATH = path.join(
-  os.homedir(),
-  'Library',
-  'Application Support',
-  'Code',
-  'User',
-  'globalStorage',
-  'rooveterinaryinc.roo-cline',
-  'settings',
-  'mcp_settings.json'
-);
+function getCandidateConfigPaths() {
+  const home = os.homedir();
+  const appData = process.env.APPDATA;
+
+  const candidates = [
+    path.join(
+      home,
+      'Library',
+      'Application Support',
+      'Code',
+      'User',
+      'globalStorage',
+      'rooveterinaryinc.roo-cline',
+      'settings',
+      'mcp_settings.json'
+    ),
+    path.join(
+      process.env.XDG_CONFIG_HOME || path.join(home, '.config'),
+      'Code',
+      'User',
+      'globalStorage',
+      'rooveterinaryinc.roo-cline',
+      'settings',
+      'mcp_settings.json'
+    )
+  ];
+
+  if (appData) {
+    candidates.push(
+      path.join(
+        appData,
+        'Code',
+        'User',
+        'globalStorage',
+        'rooveterinaryinc.roo-cline',
+        'settings',
+        'mcp_settings.json'
+      )
+    );
+  }
+
+  return candidates;
+}
 
 // -------------------------------------------------------
 // Extra fields that Roo Code uses beyond the basic MCP server config.
@@ -33,12 +65,17 @@ const EXTRA_FIELDS = ['timeout', 'type', 'disabled', 'alwaysAllow'];
  * @returns {string | null} Absolute config path if the file exists, otherwise null.
  */
 function discover() {
-  try {
-    fs.accessSync(CONFIG_PATH, fs.constants.R_OK);
-    return CONFIG_PATH;
-  } catch (_) {
-    return null;
+  const candidates = getCandidateConfigPaths();
+  for (const configPath of candidates) {
+    try {
+      fs.accessSync(configPath, fs.constants.R_OK);
+      return configPath;
+    } catch (_) {
+      // Try next candidate.
+    }
   }
+
+  return null;
 }
 
 // -------------------------------------------------------
@@ -133,6 +170,7 @@ function writeMcpServers(servers) {
 module.exports = {
   name: 'roo-code',
   discover,
+  getCandidateConfigPaths,
   parseMcpServers,
   writeMcpServers,
 };

--- a/scripts-mcp/lib/tools/roo-code.test.js
+++ b/scripts-mcp/lib/tools/roo-code.test.js
@@ -12,6 +12,12 @@ function tmpFile(name) {
   return path.join(TMPDIR, name);
 }
 
+function tmpDir(name) {
+  const dir = path.join(TMPDIR, name);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
 function writeRaw(filePath, content) {
   fs.writeFileSync(filePath, content, 'utf8');
 }
@@ -21,71 +27,133 @@ function readRaw(filePath) {
 }
 
 function cleanup() {
-  for (const file of fs.readdirSync(TMPDIR)) {
-    try { fs.unlinkSync(path.join(TMPDIR, file)); } catch (_) { /* best effort */ }
+  fs.rmSync(TMPDIR, { recursive: true, force: true });
+}
+
+const realHomedir = os.homedir;
+const realXdgConfigHome = process.env.XDG_CONFIG_HOME;
+const realAppData = process.env.APPDATA;
+let fakeHome = null;
+
+function stubHomedir(home) {
+  fakeHome = home;
+  os.homedir = () => fakeHome;
+}
+
+function restoreEnv() {
+  os.homedir = realHomedir;
+  if (realXdgConfigHome === undefined) {
+    delete process.env.XDG_CONFIG_HOME;
+  } else {
+    process.env.XDG_CONFIG_HOME = realXdgConfigHome;
+  }
+
+  if (realAppData === undefined) {
+    delete process.env.APPDATA;
+  } else {
+    process.env.APPDATA = realAppData;
   }
 }
 
-const EXPECTED_CONFIG_PATH = path.join(
-  os.homedir(),
-  'Library',
-  'Application Support',
-  'Code',
-  'User',
-  'globalStorage',
-  'rooveterinaryinc.roo-cline',
-  'settings',
-  'mcp_settings.json'
-);
-
-// -------------------------------------------------------
-// discover() tests
-// -------------------------------------------------------
-
-describe('roo-code discover()', () => {
-  it('returns configPath when file exists', () => {
-    // Ensure the directory and file exist at the real Roo Code path
-    fs.mkdirSync(path.dirname(EXPECTED_CONFIG_PATH), { recursive: true });
-    writeRaw(EXPECTED_CONFIG_PATH, JSON.stringify({ mcpServers: {} }, null, 2));
-
-    delete require.cache[require.resolve('./roo-code.js')];
-    const rooCode = require('./roo-code.js');
-    const result = rooCode.discover();
-
-    assert.equal(result, EXPECTED_CONFIG_PATH);
-
-    // Cleanup
-    try { fs.unlinkSync(EXPECTED_CONFIG_PATH); } catch (_) { /* best effort */ }
-    try { fs.rmdirSync(path.dirname(EXPECTED_CONFIG_PATH)); } catch (_) { /* best effort */ }
-    try { fs.rmdirSync(path.dirname(path.dirname(EXPECTED_CONFIG_PATH))); } catch (_) { /* best effort */ }
+describe('roo-code', () => {
+  beforeEach(() => {
+    restoreEnv();
   });
 
-  it('returns null when file does not exist', () => {
-    let renamed = false;
-    if (fs.existsSync(EXPECTED_CONFIG_PATH)) {
-      const bakPath = EXPECTED_CONFIG_PATH + '.testbak';
-      fs.renameSync(EXPECTED_CONFIG_PATH, bakPath);
-      renamed = true;
-    }
-
-    try {
-      delete require.cache[require.resolve('./roo-code.js')];
-      const rooCode = require('./roo-code.js');
-      const result = rooCode.discover();
-
-      assert.equal(result, null);
-    } finally {
-      if (renamed) {
-        const bakPath = EXPECTED_CONFIG_PATH + '.testbak';
-        try { fs.renameSync(bakPath, EXPECTED_CONFIG_PATH); } catch (_) { /* best effort */ }
-      }
-    }
+  afterEach(() => {
+    restoreEnv();
+    cleanup();
   });
 });
 
-// -------------------------------------------------------
-// parseMcpServers() tests
-// -------------------------------------------------------
+describe('roo-code discover()', () => {
+  it('returns macOS configPath when file exists', () => {
+    const home = tmpDir('home-macos');
+    const configPath = path.join(
+      home,
+      'Library',
+      'Application Support',
+      'Code',
+      'User',
+      'globalStorage',
+      'rooveterinaryinc.roo-cline',
+      'settings',
+      'mcp_settings.json'
+    );
+
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    writeRaw(configPath, JSON.stringify({ mcpServers: {} }, null, 2));
+
+    stubHomedir(home);
+    delete require.cache[require.resolve('./roo-code.js')];
+    const rooCode = require('./roo-code.js');
+
+    assert.equal(rooCode.discover(), configPath);
+  });
+
+  it('returns Linux configPath when file exists in XDG config home', () => {
+    const home = tmpDir('home-linux');
+    const xdgConfigHome = path.join(home, '.config');
+    const configPath = path.join(
+      xdgConfigHome,
+      'Code',
+      'User',
+      'globalStorage',
+      'rooveterinaryinc.roo-cline',
+      'settings',
+      'mcp_settings.json'
+    );
+
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    writeRaw(configPath, JSON.stringify({ mcpServers: {} }, null, 2));
+
+    stubHomedir(home);
+    process.env.XDG_CONFIG_HOME = xdgConfigHome;
+    delete require.cache[require.resolve('./roo-code.js')];
+    const rooCode = require('./roo-code.js');
+
+    assert.equal(rooCode.discover(), configPath);
+  });
+
+  it('returns Windows configPath when file exists in APPDATA', () => {
+    const home = tmpDir('home-windows');
+    const xdgConfigHome = path.join(home, '.config');
+    const appData = path.join(home, 'AppData', 'Roaming');
+    const configPath = path.join(
+      appData,
+      'Code',
+      'User',
+      'globalStorage',
+      'rooveterinaryinc.roo-cline',
+      'settings',
+      'mcp_settings.json'
+    );
+
+    fs.rmSync(xdgConfigHome, { recursive: true, force: true });
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    writeRaw(configPath, JSON.stringify({ mcpServers: {} }, null, 2));
+
+    stubHomedir(home);
+    process.env.XDG_CONFIG_HOME = xdgConfigHome;
+    process.env.APPDATA = appData;
+    delete require.cache[require.resolve('./roo-code.js')];
+    const rooCode = require('./roo-code.js');
+
+    assert.equal(rooCode.discover(), configPath);
+  });
+
+  it('returns null when file does not exist in any supported location', () => {
+    const home = tmpDir('home-missing');
+
+    stubHomedir(home);
+    delete process.env.XDG_CONFIG_HOME;
+    delete process.env.APPDATA;
+    delete require.cache[require.resolve('./roo-code.js')];
+    const rooCode = require('./roo-code.js');
+
+    assert.equal(rooCode.discover(), null);
+  });
+});
 
 describe('roo-code parseMcpServers()', () => {
   it('extracts all fields including extras (timeout, type, disabled, alwaysAllow)', () => {
@@ -141,7 +209,6 @@ describe('roo-code parseMcpServers()', () => {
 
     assert.equal(result.length, 2);
 
-    // Minimal server: extra fields should be undefined
     const minimal = result.find((s) => s.key === 'minimal');
     assert.equal(minimal.command, 'node');
     assert.deepStrictEqual(minimal.args, ['server.js']);
@@ -151,7 +218,6 @@ describe('roo-code parseMcpServers()', () => {
     assert.equal(minimal.alwaysAllow, undefined);
     assert.equal(minimal.env, undefined);
 
-    // Partial server: only specified extras present
     const partial = result.find((s) => s.key === 'partial');
     assert.equal(partial.command, 'npx');
     assert.equal(partial.timeout, 30);
@@ -237,10 +303,6 @@ describe('roo-code parseMcpServers()', () => {
   });
 });
 
-// -------------------------------------------------------
-// writeMcpServers() tests
-// -------------------------------------------------------
-
 describe('roo-code writeMcpServers()', () => {
   it('wraps in Roo Code schema preserving all extra fields', () => {
     const p = tmpFile('roo-write-full.json');
@@ -261,7 +323,6 @@ describe('roo-code writeMcpServers()', () => {
     const rooCode = require('./roo-code.js');
     const configObj = rooCode.writeMcpServers(servers);
 
-    // writeMcpServers returns a plain object (not written to disk)
     assert.ok(configObj.mcpServers, 'should have mcpServers key');
     assert.ok(configObj.mcpServers.anthropic, 'should have server entry');
 
@@ -274,7 +335,6 @@ describe('roo-code writeMcpServers()', () => {
     assert.equal(server.disabled, false);
     assert.deepStrictEqual(server.alwaysAllow, ['tool1', 'tool2']);
 
-    // Write to disk via config-io to verify it serializes correctly
     const { writeConfig } = require('../config-io.js');
     const writeResult = writeConfig(p, configObj);
     assert.equal(writeResult.ok, true);
@@ -302,7 +362,6 @@ describe('roo-code writeMcpServers()', () => {
 
     assert.equal(server.command, 'node');
     assert.deepStrictEqual(server.args, ['server.js']);
-    // Extra fields should NOT be present
     assert.equal('timeout' in server, false, 'timeout should not be in output');
     assert.equal('type' in server, false, 'type should not be in output');
     assert.equal('disabled' in server, false, 'disabled should not be in output');
@@ -354,10 +413,6 @@ describe('roo-code writeMcpServers()', () => {
   });
 });
 
-// -------------------------------------------------------
-// Round-trip test
-// -------------------------------------------------------
-
 describe('roo-code round-trip', () => {
   it('parse -> pass through -> write preserves all extra fields', () => {
     const p = tmpFile('roo-roundtrip.json');
@@ -389,38 +444,16 @@ describe('roo-code round-trip', () => {
     delete require.cache[require.resolve('./roo-code.js')];
     const rooCode = require('./roo-code.js');
 
-    // Parse
     const parsed = rooCode.parseMcpServers(p, originalConfig);
-
-    // Write back (returns object, not written to disk)
     const configObj = rooCode.writeMcpServers(parsed);
 
-    // Verify the object matches original
     const originalServers = originalConfig.mcpServers;
     const roundTrippedServers = configObj.mcpServers;
 
-    // Full server: all fields preserved
-    assert.deepStrictEqual(
-      roundTrippedServers['full-server'],
-      originalServers['full-server'],
-      'full-server should have identical round-trip'
-    );
+    assert.deepStrictEqual(roundTrippedServers['full-server'], originalServers['full-server']);
+    assert.deepStrictEqual(roundTrippedServers['partial-server'], originalServers['partial-server']);
+    assert.deepStrictEqual(roundTrippedServers['minimal-server'], originalServers['minimal-server']);
 
-    // Partial server: all present fields preserved, absent fields stay absent
-    assert.deepStrictEqual(
-      roundTrippedServers['partial-server'],
-      originalServers['partial-server'],
-      'partial-server should have identical round-trip'
-    );
-
-    // Minimal server: only basic fields preserved
-    assert.deepStrictEqual(
-      roundTrippedServers['minimal-server'],
-      originalServers['minimal-server'],
-      'minimal-server should have identical round-trip'
-    );
-
-    // Also verify it serializes and reads back correctly via config-io
     const { writeConfig, readConfig } = require('../config-io.js');
     const writeResult = writeConfig(p, configObj);
     assert.equal(writeResult.ok, true);
@@ -469,10 +502,6 @@ describe('roo-code round-trip', () => {
     });
   });
 });
-
-// -------------------------------------------------------
-// Module exports
-// -------------------------------------------------------
 
 describe('module exports', () => {
   it('exports name as "roo-code"', () => {


### PR DESCRIPTION
## Summary
- Add Linux/XDG config discovery for Cline MCP settings
- Add Linux/XDG config discovery for Roo Code MCP settings
- Add cross-platform discovery tests for macOS, Linux, and Windows paths

## Testing
- npm test (156 tests pass)
- biome check (0 errors)

Fixes #3