### PR TITLE
Release v1.3.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Claude Code plugin for bulk-updating installed plugin marketplaces",
-    "version": "1.3.2"
+    "version": "1.3.3"
   },
   "plugins": [
     {
       "name": "update-all-plugins",
       "source": "./",
       "description": "Bulk-update all installed Claude Code plugin marketplaces via /update-all-plugins slash command",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "author": {
         "name": "kianwoonwong"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-update-all",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "description": "Bulk-update Claude Code plugins, MCP servers, and editor extensions",
   "scripts": {


### PR DESCRIPTION
## Summary

Version bump for v1.3.3 release.

### Changes since v1.3.2

- **Fix bootstrap deadlock**: Allow auto-reinstall in `--check` mode so users on old cached versions (v1.1.0) can self-recover. Previously `--check` skipped auto-reinstall, trapping users on broken versions.

### Files changed
- `package.json` — version 1.3.2 → 1.3.3
- `.claude-plugin/marketplace.json` — version 1.3.2 → 1.3.3
- `scripts/cc-update-all.sh` — auto-reinstall now runs in check mode

### Verification
- [x] 156 tests pass
- [x] Biome lint clean