### PR TITLE
fix: resolve 9 critical/high bugs from code review

### DIFF
--- a/scripts-mcp/lib/config-io.js
+++ b/scripts-mcp/lib/config-io.js
@@ -40,7 +40,7 @@ function readConfig(configPath) {
  * @param {object} data - Data to write.
  * @returns {{ ok: true } | { ok: false, error: string }}
  */
-function writeConfig(configPath, data) {
+function writeConfig(configPath, data, options = {}) {
   const bakPath = `${configPath}.bak`;
   const tmpPath = `${configPath}.tmp`;
 
@@ -123,10 +123,10 @@ function writeConfig(configPath, data) {
     // rename() preserves the source file's mtime on POSIX, so the post-rename
     // stat of configPath should match the pre-rename .tmp mtime.
     // If it differs, an external process modified the file after our rename.
-    if (hadOriginal && tmpMtimeMs !== null) {
+    if (!options.force && hadOriginal && tmpMtimeMs !== null) {
       try {
         const statAfter = fs.statSync(configPath);
-        if (statAfter.mtimeMs !== tmpMtimeMs) {
+        if (Math.abs(statAfter.mtimeMs - tmpMtimeMs) > 1) {
           // mtime differs — external process modified the file after our rename.
           // Restore from .bak to ensure original content is intact.
           try {

--- a/scripts-mcp/lib/npm-resolver.js
+++ b/scripts-mcp/lib/npm-resolver.js
@@ -52,7 +52,7 @@ function extractPinnedVersion(args) {
     const versionAt = pkgArg.indexOf('@', firstSlash + 1);
     if (versionAt === -1) {
       // No version specified — floating
-      return { status: 'skipped_floating' };
+      return { status: 'skipped_floating', pkg: pkgArg, pkgArg, pinned: null };
     }
     pkg = pkgArg.substring(0, versionAt);
     version = pkgArg.substring(versionAt + 1);
@@ -60,7 +60,7 @@ function extractPinnedVersion(args) {
     // Unscoped package: name@version or name@version/sub/path
     const versionAt = pkgArg.indexOf('@');
     if (versionAt === -1) {
-      return { status: 'skipped_floating' };
+      return { status: 'skipped_floating', pkg: pkgArg, pkgArg, pinned: null };
     }
     pkg = pkgArg.substring(0, versionAt);
     version = pkgArg.substring(versionAt + 1);
@@ -74,10 +74,17 @@ function extractPinnedVersion(args) {
 
   // Check if version is a floating tag
   if (FLOATING_TAGS.has(version.toLowerCase())) {
-    return { status: 'skipped_floating' };
+    return { status: 'skipped_floating', pkg, pkgArg, pinned: version };
   }
 
-  return { pkg, pinned: version };
+  // Check if version is a semver range (not a pinned version)
+  const RANGE_PREFIXES = ['^', '~', '>=', '<=', '>', '<', '*', 'x'];
+  const isRange = RANGE_PREFIXES.some(p => version.startsWith(p)) || version.includes('||') || version.includes(' - ');
+  if (isRange) {
+    return { status: 'skipped_floating', pkg, pkgArg, pinned: version };
+  }
+
+  return { pkg, pkgArg, pinned: version };
 }
 
 // -------------------------------------------------------

--- a/scripts-mcp/lib/tools/cline.js
+++ b/scripts-mcp/lib/tools/cline.js
@@ -20,7 +20,11 @@ function getCandidateConfigPaths() {
       'cline_mcp_settings.json',
     ),
     path.join(
-      process.env.XDG_CONFIG_HOME || path.join(home, '.config'),
+      process.env.XDG_CONFIG_HOME
+        ? (path.isAbsolute(process.env.XDG_CONFIG_HOME)
+            ? process.env.XDG_CONFIG_HOME
+            : path.join(home, process.env.XDG_CONFIG_HOME))
+        : path.join(home, '.config'),
       'Code',
       'User',
       'globalStorage',

--- a/scripts-mcp/lib/tools/roo-code.js
+++ b/scripts-mcp/lib/tools/roo-code.js
@@ -1,7 +1,6 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
-const { writeConfig } = require('../config-io');
 
 function getCandidateConfigPaths() {
   const home = os.homedir();
@@ -20,7 +19,11 @@ function getCandidateConfigPaths() {
       'mcp_settings.json',
     ),
     path.join(
-      process.env.XDG_CONFIG_HOME || path.join(home, '.config'),
+      process.env.XDG_CONFIG_HOME
+        ? (path.isAbsolute(process.env.XDG_CONFIG_HOME)
+            ? process.env.XDG_CONFIG_HOME
+            : path.join(home, process.env.XDG_CONFIG_HOME))
+        : path.join(home, '.config'),
       'Code',
       'User',
       'globalStorage',
@@ -129,9 +132,12 @@ function parseMcpServers(_configPath, rawJson) {
 // -------------------------------------------------------
 
 /**
+ * Returns the MCP server configuration data for the caller to write.
  * Wraps an array of server entries into the Roo Code MCP config schema.
  * Receives the COMPLETE array (both updated and unchanged entries).
  * Extra fields from parseMcpServers() are preserved in output.
+ * Note: Unlike cline.js, this function does NOT write to disk — it returns
+ * the data object for the caller (update-mcp.js) to write via config-io.
  *
  * @param {Array} servers - Complete array of server entries (output of parseMcpServers).
  * @returns {{ mcpServers: { [key: string]: object } }}

--- a/scripts-mcp/update-mcp.js
+++ b/scripts-mcp/update-mcp.js
@@ -135,12 +135,22 @@ async function processTool(discoveredTool, opts) {
 
       // Mutate the server args to update the version
       for (let j = 0; j < server.args.length; j++) {
-        if (server.args[j].includes(extracted.pkg)) {
-          server.args[j] = server.args[j].replace(
-            `${extracted.pkg}@${extracted.pinned}`,
-            `${extracted.pkg}@${resolveResult.latest}`,
-          );
-          break;
+        const arg = server.args[j];
+        // Match exact pkgArg or pkg@version pattern
+        const pattern = `${extracted.pkg}@`;
+        const atIdx = arg.indexOf(pattern);
+        if (atIdx !== -1) {
+          const prefix = arg.substring(0, atIdx + pattern.length);
+          const oldVersion = arg.substring(atIdx + pattern.length);
+          // Only replace if the version part matches what we extracted
+          if (oldVersion === extracted.pinned) {
+            const newArg = prefix + resolveResult.latest;
+            if (newArg !== arg) {
+              server.args[j] = newArg;
+              hasUpdates = true;
+              break;
+            }
+          }
         }
       }
     }
@@ -151,7 +161,7 @@ async function processTool(discoveredTool, opts) {
   // -- Write back if there are updates and not in check/dry-run mode
   if (hasUpdates && !opts.dryRun && !opts.check) {
     const writeData = tool.writeMcpServers(servers);
-    const writeResult = configIo.writeConfig(configPath, writeData);
+    const writeResult = configIo.writeConfig(configPath, writeData, { force: opts.force });
     if (!writeResult.ok) {
       toolResult.status = 'write_error';
       toolResult.writeError = writeResult.error;

--- a/scripts/cc-update-all.sh
+++ b/scripts/cc-update-all.sh
@@ -28,6 +28,7 @@ trap 'rm -rf "$SUMMARY_DIR"' EXIT
 
 # Touch the result files
 : > "${SUMMARY_DIR}/partial_failure"
+: > "${SUMMARY_DIR}/mp_names"
 
 # ---------------------------------------------------------------------------
 # Color support — disabled when piped or in --json mode
@@ -71,13 +72,17 @@ dim()   { printf "${_COLOR_DIM}%s${_COLOR_RESET}\n" "$*"; }
 
 has_jq() { command -v jq &>/dev/null; }
 
+_json_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n' ' '
+}
+
 # Result accumulator — stores per-marketplace results as tab-separated files:
 #   ${SUMMARY_DIR}/mp_<name>  = status<TAB>before<TAB>after<TAB>plugins
 record_mp_result() {
   local name="$1" status="$2" before="$3" after="$4" plugins="$5"
-  # Sanitize name for filename
+  # Hash-based safe name to avoid filename collisions
   local safe_name
-  safe_name=$(printf '%s' "$name" | tr -c 'a-zA-Z0-9_-' '_')
+  safe_name=$(printf '%s' "$name" | shasum -a 256 | cut -c1-16)
   printf '%s\t%s\t%s\t%s\n' "$status" "$before" "$after" "$plugins" > "${SUMMARY_DIR}/mp_${safe_name}"
   # Keep a list of marketplace names in order
   echo "$name" >> "${SUMMARY_DIR}/mp_names"
@@ -91,7 +96,7 @@ get_mp_field() {
   # $1=name $2=field_index (0=status, 1=before, 2=after, 3=plugins)
   local name="$1" idx="$2"
   local safe_name
-  safe_name=$(printf '%s' "$name" | tr -c 'a-zA-Z0-9_-' '_')
+  safe_name=$(printf '%s' "$name" | shasum -a 256 | cut -c1-16)
   local line
   line=$(cat "${SUMMARY_DIR}/mp_${safe_name}" 2>/dev/null) || return 1
   echo "$line" | cut -f$((idx + 1))
@@ -302,6 +307,10 @@ update_marketplace() {
   local upstream
   upstream="$(git -C "$install_dir" rev-parse --abbrev-ref "@{upstream}" 2>/dev/null || true)"
 
+  # Get before SHA (must be before upstream check since it's used there)
+  local before_sha
+  before_sha="$(git -C "$install_dir" rev-parse --short HEAD 2>/dev/null || echo "unknown")"
+
   if [[ -z "$upstream" ]]; then
     record_mp_result "$name" "no_upstream" "$before_sha" "$before_sha" "$plugins"
     warn "  [SKIPPED] ${name}  no upstream branch configured"
@@ -311,10 +320,6 @@ update_marketplace() {
   local remote branch_name
   remote="${upstream%%/*}"
   branch_name="${upstream#*/}"
-
-  # Get before SHA
-  local before_sha
-  before_sha="$(git -C "$install_dir" rev-parse --short HEAD 2>/dev/null || echo "unknown")"
 
   if [[ "$_DRY_RUN" -eq 1 ]]; then
     record_mp_result "$name" "dry_run" "$before_sha" "${before_sha} (would update)" "$plugins"
@@ -490,7 +495,9 @@ print_summary_json() {
           else
             plugins_json+=", "
           fi
-          plugins_json+="\"${plugin}\""
+          local ep
+          ep="$(_json_escape "$plugin")"
+          plugins_json+="\"${ep}\""
         done
         IFS="$IFS_SAVE"
         plugins_json+="]"
@@ -510,12 +517,18 @@ print_summary_json() {
         *)             output_status="$status" ;;
       esac
 
+      local en es eb ea
+      en="$(_json_escape "$name")"
+      es="$(_json_escape "$output_status")"
+      eb="$(_json_escape "$before")"
+      ea="$(_json_escape "$after")"
+
       marketplaces_json+="${comma}
     {
-      \"name\": \"${name}\",
-      \"status\": \"${output_status}\",
-      \"before\": \"${before}\",
-      \"after\": \"${after}\",
+      \"name\": \"${en}\",
+      \"status\": \"${es}\",
+      \"before\": \"${eb}\",
+      \"after\": \"${ea}\",
       \"installed_plugins\": ${plugins_json}
     }"
     done <<< "$sorted_names"
@@ -529,6 +542,9 @@ print_summary_json() {
 # ---------------------------------------------------------------------------
 main() {
   parse_args "$@"
+
+  # Check for required tools
+  command -v git &>/dev/null || { echo "Error: git is required but not found in PATH" >&2; exit 2; }
 
   # Check for required files
   if [[ ! -f "$_INSTALLED_PLUGINS_FILE" ]]; then


### PR DESCRIPTION
## Summary

Fixes all critical and high severity bugs identified during the comprehensive code review of `cc-update-all` v1.3.3.

### Critical Fixes
- **#7** — `$before_sha` used before assignment, crashes under `set -u` when marketplace has no upstream
- **#8** — Version replace uses loose `includes()` matching, can corrupt unrelated MCP server args
- **#9** — Strict mtime float equality causes false-positive rollback on APFS, discarding valid writes
- **#10** — Unescaped values in no-jq JSON fallback output — potential JSON injection

### High Fixes
- **#11** — `--force` flag was dead code (parsed but never wired to `writeConfig`) + missing `mp_names` initialization + missing `git` availability check
- **#12** — `tr` sanitization causes filename collisions (e.g., `my-plugin` and `my.plugin` both become `my_plugin`)
- **#13** — Semver range operators (`^`, `~`, etc.) not detected — ranges silently converted to pinned versions
- **#14** — Relative `XDG_CONFIG_HOME` not resolved against `$HOME` — wrong paths on NixOS/containers
- **#15** — `roo-code.js` `writeMcpServers` JSDoc misleading + unused import cleanup

### Test Coverage Gap (tracked separately)
- **#16** — Critical untested paths: `processTool`, both `main` functions, `registry` module loader

## Files Changed
- `scripts/cc-update-all.sh` — 5 fixes (uninitialized var, JSON escaping, filename hashing, init file, git check)
- `scripts-mcp/update-mcp.js` — version matching precision + force flag wiring
- `scripts-mcp/lib/config-io.js` — mtime tolerance + force option support
- `scripts-mcp/lib/npm-resolver.js` — semver range detection
- `scripts-mcp/lib/tools/cline.js` — XDG path resolution
- `scripts-mcp/lib/tools/roo-code.js` — XDG path + JSDoc fix + unused import removal

## Test plan
- [x] All 156 existing tests pass
- [x] Shell script syntax validated (`bash -n`)
- [ ] Manual test: run `/update-all-plugins` with a marketplace that has no upstream
- [ ] Manual test: run `/update-mcp-servers --force` to verify force flag works
- [ ] Manual test: verify mtime safety check no longer false-positives on macOS APFS